### PR TITLE
Making subreddit prefixing activatable

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -24,6 +24,8 @@ print(f'PROJECT_FOLDER = {PROJECT_FOLDER}')
 parser = argparse.ArgumentParser()
 parser.add_argument('--data', type=str, default='dummy',
                     help='choose from dummy, small and full')
+parser.add_argument('--subreddit_prefix', action='store_true', default=False,
+                    help='Prefix each comment in the training data with the subreddit from which the thread was taken')
 dargs = parser.parse_args()
 
 assert dargs.data == 'dummy' or dargs.data == 'small' or dargs.data == 'full' , \
@@ -64,11 +66,11 @@ if dargs.data == 'dummy':
     cmd = 'bash prepare4db.sh'
     ret = sp.run(cmd.split(' '), stdout=sp.PIPE, stderr=sp.STDOUT, cwd=DATA_FOLDER)
 elif dargs.data == 'small':
-    myCmd = os.popen('cd reddit_extractor; make -j 8; cd ..').read()
+    myCmd = os.popen('cd reddit_extractor; SUBREDDIT_PREFIX={} SIZE=small make -j 8; cd ..'.format(dargs.subreddit_prefix)).read()
     cmd = 'gzip -d ./train.tsv.gz'
     ret = sp.run(cmd.split(' '), stdout=sp.PIPE, stderr=sp.STDOUT, cwd=DATA_FOLDER)
 elif dargs.data == 'full':
-    myCmd = os.popen('cd reddit_extractor; SIZE=full make -j 8; cd ..').read()
+    myCmd = os.popen('cd reddit_extractor; SUBREDDIT_PREFIX={} SIZE=full make -j 8; cd ..'.format(dargs.subreddit_prefix)).read()
     cmd = 'gzip -d ./train.tsv.gz'
     ret = sp.run(cmd.split(' '), stdout=sp.PIPE, stderr=sp.STDOUT, cwd=DATA_FOLDER)
 else:

--- a/reddit_extractor/Makefile
+++ b/reddit_extractor/Makefile
@@ -34,7 +34,7 @@ $T/test/$A/%.tsv.gz: $T/test/$P/%/stat.tsv
 
 $T/train/$A/%.tsv.gz: $T/train/$P/%/stat.tsv
 	mkdir -p $T/train/$A
-	python src/reddit.py $(*F) --task=conv $(HASH_FLAG) --keep_keys=$K/$(*F).gz --discard_tgt_keys $K/$(*F)-o.gz --parallel=True $(WORDS_BLOCKLIST) $(SUBREDDITS_BLOCKLIST) --reddit_input $S --reddit_output $T/train --clean True --min_score $(MIN_SCORE) --min_depth $(MIN_DEPTH) --max_depth $(MAX_DEPTH) --use_title $(TITLE) --leaves_only $(LEAVES_ONLY) > $@.log 2>&1
+	python src/reddit.py $(*F) --task=conv $(HASH_FLAG) --keep_keys=$K/$(*F).gz --discard_tgt_keys $K/$(*F)-o.gz --parallel=True $(WORDS_BLOCKLIST) $(SUBREDDITS_BLOCKLIST) --reddit_input $S --reddit_output $T/train --clean True --min_score $(MIN_SCORE) --min_depth $(MIN_DEPTH) --max_depth $(MAX_DEPTH) --use_title $(TITLE) --leaves_only $(LEAVES_ONLY) $(SUBREDDIT_PREFIX_FLAG) > $@.log 2>&1
 	gzip -f $T/train/$A/$(*F).tsv
 
 $T/test/$P/%/stat.tsv: $S/RS_%.bz2 $S/RC_%.bz2

--- a/reddit_extractor/configs/Makefile.local
+++ b/reddit_extractor/configs/Makefile.local
@@ -62,5 +62,9 @@ ifndef SIZE
 SIZE=small
 endif
 
+ifeq ($(SUBREDDIT_PREFIX), True)
+SUBREDDIT_PREFIX_FLAG=--subreddit_prefix
+endif
+
 include configs/Makefile.targets.$(SIZE)
 include configs/Makefile.common

--- a/reddit_extractor/src/reddit.py
+++ b/reddit_extractor/src/reddit.py
@@ -57,7 +57,7 @@ parser.add_argument("--parallel", default=False, type=bool)
 parser.add_argument("--pre_tok", default=False, type=bool, help="whether to tokenize during the extract step")
 parser.add_argument("--clean", default=False, type=bool,
                     help="apply some filters to significantly reduce number of instances")
-parser.add_argument("--subreddit_prefix", default=False, type=bool,
+parser.add_argument("--subreddit_prefix", default=False, action='store_true',
                     help="prefix each turn of the conversation with the name of the subreddit from which it was taken")
 
 args = parser.parse_args()
@@ -530,6 +530,9 @@ if args.task == 'extract':
     extract()
 elif args.task == 'conv':
     fld_out = fld_root_out + '/conv'
+    if args.subreddit_prefix:
+        # XXX diagnostic
+        print("Subreddit being interleaved amongst conversation turns")
     build_conv(fld_out, args.subreddit_prefix)
 else:
     print("Unknown task: %s" % args.task, file=sys.stderr)

--- a/reddit_extractor/src/reddit.py
+++ b/reddit_extractor/src/reddit.py
@@ -530,9 +530,6 @@ if args.task == 'extract':
     extract()
 elif args.task == 'conv':
     fld_out = fld_root_out + '/conv'
-    if args.subreddit_prefix:
-        # XXX diagnostic
-        print("Subreddit being interleaved amongst conversation turns")
     build_conv(fld_out, args.subreddit_prefix)
 else:
     print("Unknown task: %s" % args.task, file=sys.stderr)


### PR DESCRIPTION
I made it easier to invoke the subreddit prefixing functionality.  Rather than modify the Makefile, one need only pass in a command line argument to `demo.py`.  Default behavior is preserved for backwards-compatibility.